### PR TITLE
fix: Resolve uv lock file out-of-sync status with `pyproject.toml`

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -1,6 +1,6 @@
 version = 1
 revision = 3
-requires-python = ">=3.11, <=3.13"
+requires-python = ">=3.11, <3.14"
 
 [[package]]
 name = "annotated-types"


### PR DESCRIPTION
### Description

The `pyproject.toml` file on the main branch was updated in [[this commit](https://github.com/ikollipara/django-meili/commit/8a18cd4ad363990a12fe6aba1e9e89026faa3048)](https://github.com/ikollipara/django-meili/commit/8a18cd4ad363990a12fe6aba1e9e89026faa3048):

```diff
- requires-python = ">=3.11,<=3.13"
+ requires-python = ">=3.11,<3.14"
```


However, `uv sync` wasn’t run afterward, so the `uv.lock` file got out of sync. This caused issues with the environment, and running `uv sync` now shows that there are new changes in the `uv.lock` file.

This PR fixes that by running:

```bash
uv sync
```

Now the `uv.lock` file matches `pyproject.toml` and everything should work correctly.
