### PR TITLE
fix: Resolve #35 by fixing test action permission issue in workflow

### DIFF
--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -35,4 +35,4 @@ jobs:
           pip install -r requirements.txt
 
       - name: Test package
-        run: ./manage.py test
+        run: python manage.py test


### PR DESCRIPTION
### Description

This PR fixes  [Issue#35](https://github.com/ikollipara/django-meili/issues/35) where the workflow failed during the **"Test package"** step when running locally with `act`.
The issue occurred because `./manage.py` lacked execute permissions in the local Docker environment.


### Result

The workflow now runs successfully both in CI and when executed locally using `act`.